### PR TITLE
Added static library build

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ ifeq ($(OS),Windows_NT)
 #windows stuff here
 	MD=mkdir
 	LIBFILE=libjupitermag.dll
+	ARCFILE=jupitermag.lib
 else
 #linux and mac here
 	OS=$(shell uname -s)
@@ -26,6 +27,7 @@ else
 	else
 		LIBFILE=libjupitermag.dylib
 	endif
+	ARCFILE=libjupitermag.a
 	MD=mkdir -p
 endif
 
@@ -88,6 +90,7 @@ test:
 install:
 	cp -v include/jupitermag.h $(PREFIX_INC)
 	cp -v lib/$(LIBFILE) $(PREFIX_LIB)
+	cp -v lib/$(ARCFILE) $(PREFIX_LIB)
 	chmod 0775 $(PREFIX_LIB)/$(LIBFILE)
 ifeq ($(OS),Linux)
 	-ldconfig

--- a/src/makefile
+++ b/src/makefile
@@ -18,8 +18,10 @@ endif
 OS=$(shell uname -s)
 ifeq ($(OS),Linux)
 	LIBFILE=libjupitermag.so
+	ARCFILE=libjupitermag.a
 else
 	LIBFILE=libjupitermag.dylib
+	ARCFILE=libjupitermag.a
 endif
 
 all: header obj lib
@@ -39,11 +41,12 @@ obj:
 	$(CCo) interptraceclosestpos.cc -o $(BUILDDIR)/interptraceclosestpos.o 
 	$(CCo) footprint.cc -o $(BUILDDIR)/footprint.o
 	$(CCo) coordconv.cc -o $(BUILDDIR)/coordconv.o 
+	$(CCo) libjupitermag.cc -o $(BUILDDIR)/libjupitermag.o
 	
 lib:
-	
-	$(CC) -shared libjupitermag.cc $(BUILDDIR)/*.o \
-			-o ../lib/$(LIBFILE) 
+	ar -crs ../lib/$(ARCFILE) $(BUILDDIR)/*.o
+	$(CC) -shared $(BUILDDIR)/*.o -o ../lib/$(LIBFILE)
+
 
 winobj:
 #	cd con2020;	make windows


### PR DESCRIPTION
Statically linked applications are sometimes easier to deploy.  This patch adds static library creation alongside shared object output for libjupitermag.